### PR TITLE
Initial attempt to add a no-array-mutation rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ module.exports = {
     "no-array-mutation": function(context) {
 			return {
 				"Identifier": function(node) {
-					if (node.parent.type === "MemberExpression" && arrayMethodPattern.test(node.name)) {
+          if (node.parent.type === "MemberExpression"
+            && node.parent.parent.callee === node.parent
+            && arrayMethodPattern.test(node.name)) {
 						context.report(node, "No array mutation allowed.");
 					}
 				}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var arrayMethodPattern = /^(?:push|pop|shift|unshift|fill|reverse|splice)$/;
+
 module.exports = {
     rules: {
         "no-let": function(context) {
@@ -26,17 +28,27 @@ module.exports = {
 					}
 				}
 			}
-		}		
     },
+    "no-array-mutation": function(context) {
+			return {
+				"Identifier": function(node) {
+					if (node.parent.type === "MemberExpression" && arrayMethodPattern.test(node.name)) {
+						context.report(node, "No array mutation allowed.");
+					}
+				}
+			}
+		}
+  },
 	configs: {
 		recommended: {
 	    	rules: {
 	        	'redux/no-let': 2,
 	        	'redux/no-this': 2,
-	        	'redux/no-mutation': 2
+	        	'redux/no-mutation': 2,
+	        	'redux/no-array-mutation': 2
 	      	}
 	    }
-	}    
+	}
 };
 
 


### PR DESCRIPTION
Hi

This is currently a simplistic check that looks for calls of array methods that mutate.
Not restricted to arrays currently so will actually block any method calls with push, pop, splice, shift, unshift or reverse, e.g. this currently warns if I use `const newArray = R.reverse(array)`

I'm new to Eslint and so I'm not sure if there is a way to make this check more specific to arrays.
