### PR TITLE
Add exception support to no-mutation rule

### DIFF
--- a/check_exceptions.js
+++ b/check_exceptions.js
@@ -1,0 +1,37 @@
+function match(value, exception) {
+  return value === exception;
+}
+
+function checkExceptions(node, exceptions) {
+  if (!exceptions || !exceptions.length) {
+    return false;
+  }
+
+  var object = node.left.object.name;
+  var property = node.left.property.name;
+
+  for (var i = 0, length = exceptions.length; i < length; i += 1) {
+    var exception = exceptions[i];
+
+    var objectMatch = match(object, exception.object);
+    var propertyMatch = match(property, exception.property);
+
+    if (exception.object && exception.property) {
+      if (objectMatch && propertyMatch) {
+        return true;
+      }
+    }
+    else if (exception.object) {
+      if (objectMatch) {
+        return true;
+      }
+    }
+    else if (exception.property) {
+      if (propertyMatch) {
+        return true;
+      }
+    }
+  }
+}
+
+module.exports = checkExceptions;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var checkExceptions = require('./check_exceptions');
+
 module.exports = {
     rules: {
         "no-let": function(context) {
@@ -21,6 +23,13 @@ module.exports = {
 		"no-mutation": function(context) {
 			return {
 				"AssignmentExpression": function(node) {
+					var options = context.options[0] || {};
+					var exceptions = options.exceptions || [];
+
+					if (checkExceptions(node, exceptions)) {
+						return;
+					}
+
 					if (node.left.type === "MemberExpression") {
 						context.report(node, "No object mutation allowed.");
 					}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "ESLint plugin to disable all mutation in JavaScript.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --recursive -s 15 test/",
+    "test-coverage": "istanbul cover _mocha -- --recursive",
+
+    "open-coverage": "open coverage/lcov-report/index.html"
   },
   "repository": {
     "type": "git",
@@ -14,6 +17,11 @@
     "eslint",
     "immutability"
   ],
+  "devDependencies": {
+    "eslint": "2.11.0",
+    "istanbul": "0.4.3",
+    "mocha": "2.5.3"
+  },
   "author": "Jafar Husain",
   "license": "Apache-2.0",
   "bugs": {

--- a/test/test_no_let.js
+++ b/test/test_no_let.js
@@ -1,0 +1,37 @@
+"use strict";
+
+var RuleTester = require("eslint").RuleTester;
+
+var rule = require("../index.js").rules['no-let'];
+var ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+
+ruleTester.run("no-let", rule, {
+  valid: [
+    "const x = 4;",
+    "const { x, y } = obj;",
+    "export const x = 4;",
+    "export const { x, y } = obj;",
+  ],
+  invalid: [{
+    code: "let x = 4;",
+    errors: [{
+      message: "Unexpected let, use const.",
+    }],
+  }, {
+    code: "export let x = 4;",
+    errors: [{
+      message: "Unexpected let, use const.",
+    }],
+  }, {
+    code: "export let { x, y } = obj;",
+    errors: [{
+      message: "Unexpected let, use const.",
+    }],
+  }],
+});

--- a/test/test_no_mutation.js
+++ b/test/test_no_mutation.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var RuleTester = require("eslint").RuleTester;
+
+var rule = require("../index.js").rules['no-mutation'];
+var ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+
+ruleTester.run("no-mutation", rule, {
+  valid: [
+    "const x = obj.y;",
+    "const { x, y } = obj;",
+    "export const x = 4;",
+    "export const { x, y } = obj;",
+    "x = 4;",
+  ],
+  invalid: [{
+    code: "obj.x = 4;",
+    errors: [{
+      message: "No object mutation allowed.",
+    }],
+  }],
+});

--- a/test/test_no_mutation.js
+++ b/test/test_no_mutation.js
@@ -17,10 +17,90 @@ ruleTester.run("no-mutation", rule, {
     "const { x, y } = obj;",
     "export const x = 4;",
     "export const { x, y } = obj;",
-    "x = 4;",
+    "x = 4;", {
+      code: "module.exports = fn;",
+      options: [{
+        exceptions: [{
+          object: 'module',
+          property: 'exports',
+        }]
+      }]
+    }, {
+      code: "module.x = fn;",
+      options: [{
+        exceptions: [{
+          object: 'module',
+        }]
+      }]
+    }, {
+      code: "x.exports = fn;",
+      options: [{
+        exceptions: [{
+          property: 'blah',
+        }, {
+          property: 'exports',
+        }],
+      }]
+    }
   ],
   invalid: [{
-    code: "obj.x = 4;",
+    code: "obj.x = 'no exceptions';",
+    errors: [{
+      message: "No object mutation allowed.",
+    }],
+  }, {
+    code: "obj.x = 'empty options object';",
+    options: [{}],
+    errors: [{
+      message: "No object mutation allowed.",
+    }],
+  }, {
+    code: "obj.x = 'empty exception array';",
+    options: [{
+      exceptions: [],
+    }],
+    errors: [{
+      message: "No object mutation allowed.",
+    }],
+  }, {
+    code: "obj.x = 'empty exception';",
+    options: [{
+      exceptions: [{}],
+    }],
+    errors: [{
+      message: "No object mutation allowed.",
+    }],
+  }, {
+    code: "obj.x = 'non-matching exceptions';",
+    options: [{
+      exceptions: [{
+        object: 'obj',
+        property: 'y',
+      }, {
+        object: 'item',
+        property: 'x',
+      }],
+    }],
+    errors: [{
+      message: "No object mutation allowed.",
+    }],
+  }, {
+    code: "obj.x = 'non-matching object exception';",
+    options: [{
+      exceptions: [{
+        object: 'item',
+      }],
+    }],
+    errors: [{
+      message: "No object mutation allowed.",
+    }],
+  }, {
+    code: "obj.x = 'non-matching property exception';",
+    options: [{
+      exceptions: [{
+        property: 'y',
+      }],
+    }],
     errors: [{
       message: "No object mutation allowed.",
     }],

--- a/test/test_no_this.js
+++ b/test/test_no_this.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var RuleTester = require("eslint").RuleTester;
+
+var rule = require("../index.js").rules['no-this'];
+var ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+
+ruleTester.run("no-this", rule, {
+  valid: [
+    "function set() { obj.x = 4; }",
+    "() => obj.x;",
+  ],
+  invalid: [{
+    code: "function set() { this.x = 4; }",
+    errors: [{
+      message: "Unexpected this, use functions not classes.",
+    }],
+  }, {
+    code: "function get() { return this.x; }",
+    errors: [{
+      message: "Unexpected this, use functions not classes.",
+    }],
+  }],
+});


### PR DESCRIPTION
By adding a `{ object: 'module', property: 'exports' }` exception, fixes #6.
By adding a `{ property: 'propTypes' }` exception, fixes #14.

You can now provide an `exceptions` array in the options for `no-mutation` in your eslint config:

``` javascript
{
  'no-mutation': ['error', {
    exceptions: [{
      object: 'module',
      property: 'exports',
    }]
  }]
}
```

Also adds tests with 100% code coverage to the project. :0)
